### PR TITLE
Pass temperature to draft sampler in dflash_generate

### DIFF
--- a/dflash/model.py
+++ b/dflash/model.py
@@ -118,7 +118,7 @@ def dflash_generate(
                 is_causal=False,
             )[:, 1 - block_size :, :])
             past_key_values_draft.crop(start)
-            block_output_ids[:, 1:] = sample(draft_logits)
+            block_output_ids[:, 1:] = sample(draft_logits, temperature)
             if draft_prefill and return_stats:
                 draft_prefill = False
                 decode_start = _cuda_time()


### PR DESCRIPTION
Closes #74.

### Problem

In `dflash_generate`, the draft sampler is invoked without the
user-supplied `temperature`:

`dflash/model.py:121` (draft):
```python
block_output_ids[:, 1:] = sample(draft_logits)            # default temperature=0.0
```

`dflash/model.py:134` (target):
```python
posterior = sample(output.logits, temperature)
```

For any `temperature > 0` the draft is therefore deterministic (greedy
argmax) while the target samples stochastically.  Acceptance is decided
by a token-equality check
(`block_output_ids[:, 1:] == posterior[:, :-1]`), so the mismatch
artificially depresses acceptance and the accepted-token distribution
does not match the target distribution.

Reproduction without a model (verbatim copy of `sample()`):

```python
import torch
def sample(logits, temperature=0.0):
    if temperature < 1e-5:
        return torch.argmax(logits, dim=-1)
    bsz, seq_len, vocab_size = logits.shape
    logits = logits.view(-1, vocab_size) / temperature
    probs = torch.softmax(logits, dim=-1)
    return torch.multinomial(probs, num_samples=1).view(bsz, seq_len)

torch.manual_seed(0)
logits = torch.tensor([[[2.0, 1.5, 1.0, 0.5]]])
draft  = sum(int(sample(logits).item() == 0) for _ in range(4000))
target = sum(int(sample(logits, 1.0).item() == 0) for _ in range(4000))
print(draft, target)   # 4000 1894
```

### Fix

Pass `temperature` through to the draft `sample()`:

```python
block_output_ids[:, 1:] = sample(draft_logits, temperature)
```

This is the minimal change that puts draft and target on the same
sampling scheme.  Acceptance is still token-equality (not
Leviathan-style rejection sampling), so `dflash_generate` still does not
provide an exact-distribution guarantee for `temperature > 0`; happy to
follow up with a docstring note or a proper rejection-sampling
implementation in a separate PR if useful.

### Notes

- Greedy callers (`temperature == 0`, the default in the README
  examples) are unaffected: both branches go through `torch.argmax`.
- This is distinct from PR #67 which targeted the **shape** returned by
  `sample()` — that one would have broken downstream broadcasting; this
  PR touches only the call site.
- One of three small correctness fixes (also #73, #75); each on its own
  branch so they can be merged independently.
