### PR TITLE
Assert _GDNStateCapture invariants in MLX rollback

### DIFF
--- a/dflash/model_mlx.py
+++ b/dflash/model_mlx.py
@@ -336,6 +336,12 @@ class _GDNStateCapture:
             _GDN_PATCH_LOCK.release()
 
     def rollback(self, cache, accepted, trim):
+        n_non_trimmable = sum(1 for c in cache if not c.is_trimmable())
+        assert n_non_trimmable == len(self._gdn_inputs), (
+            f"non-trimmable cache count ({n_non_trimmable}) != "
+            f"captured GDN inputs ({len(self._gdn_inputs)}); "
+            "DFlash MLX rollback assumes every non-trimmable cache is a GatedDeltaNet layer"
+        )
         j = 0
         for c in cache:
             if c.is_trimmable():


### PR DESCRIPTION
Closes #75.

### Problem

`_GDNStateCapture.rollback` (`dflash/model_mlx.py:338`) iterates over the
target model's cache and uses a counter `j` that advances only for
non-trimmable cache entries:

```python
def rollback(self, cache, accepted, trim):
    j = 0
    for c in cache:
        if c.is_trimmable():
            c.trim(trim)
        else:
            q, k, v, a, b, A_log, dt_bias, init_state, mask = self._gdn_inputs[j]
            ...
            conv_input, K = self.conv_data[j]
            c.cache[0] = conv_input[:, accepted + 1 : accepted + K]
            j += 1
```

The capture lists are populated only by the monkey-patched
`GatedDeltaNet.__call__`, so this works only if every non-trimmable
cache entry corresponds to exactly one `GatedDeltaNet` forward call.

That invariant is true today for the Qwen3.5 family on `mlx-lm 0.31.x`,
but it is undocumented and unguarded.  The day a new `mlx-lm` release
adds another non-trimmable cache type (a different SSM/recurrent layer,
a custom DDT cache, etc.), `j` keeps advancing for it while
`_gdn_inputs[j]` holds data from a different layer — silently producing
rollback corruption rather than an exception.

### Fix

A single `assert` at the top of `rollback` converts the silent
corruption into a loud failure with a clear message:

```python
def rollback(self, cache, accepted, trim):
    n_non_trimmable = sum(1 for c in cache if not c.is_trimmable())
    assert n_non_trimmable == len(self._gdn_inputs), (
        f"non-trimmable cache count ({n_non_trimmable}) != "
        f"captured GDN inputs ({len(self._gdn_inputs)}); "
        "DFlash MLX rollback assumes every non-trimmable cache is a GatedDeltaNet layer"
    )
    ...
```

Cheap to add, no behavioural change on the supported configurations,
and the next `mlx-lm` bump that breaks the assumption surfaces as a
clear AssertionError instead of garbage tokens.

### Notes

- One of three small correctness fixes (also #73, #74); each on its own
  branch so they can be merged independently.
- Happy to extend the assertion into a proper unit test if a test
  harness for the MLX backend is added later — right now the file has
  no test scaffolding to plug into.
