### PR TITLE
Add Gemma4 urls to supported models table

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ https://github.com/user-attachments/assets/5b29cabb-eb95-44c9-8ffe-367c0758de8c
 | Qwen3-4B (non-thinking) | [z-lab/Qwen3-4B-DFlash-b16](https://huggingface.co/z-lab/Qwen3-4B-DFlash-b16) |
 | Qwen3-8B (non-thinking) | [z-lab/Qwen3-8B-DFlash-b16](https://huggingface.co/z-lab/Qwen3-8B-DFlash-b16) |
 | Llama-3.1-8B-Instruct | [z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat](https://huggingface.co/z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat) |
+| Gemma-4-31B-it | [z-lab/gemma-4-31B-it-DFlash](https://huggingface.co/z-lab/gemma-4-31B-it-DFlash) |
+| Gemma-4-26B-A4B-it | [z-lab/gemma-4-26B-A4B-it-DFlash](https://huggingface.co/z-lab/gemma-4-26B-A4B-it-DFlash) |
 | Qwen3.5-397B-A17B | Coming soon |
 | GLM-5.1 | Coming soon |
 


### PR DESCRIPTION
## What this PR does
Adds URLs for Gemma4 dflash model in "Supported" table.

## Why
There is no information about Gemma4 support in this table despite models exist.

## Changes
- Added 2 URLs: for Gemma-4-31B-it and Gemma-4-26B-A4B-it dflash models