### PR TITLE
bug: require dflash_config.target_layer_ids instead of guessing it

### DIFF
--- a/dflash/model.py
+++ b/dflash/model.py
@@ -22,18 +22,6 @@ from transformers.models.qwen3.modeling_qwen3 import (
 # Model utilities
 # ---------------------------------------------------------------------------
 
-def build_target_layer_ids(num_target_layers: int, num_draft_layers: int):
-    if num_draft_layers == 1:
-        return [num_target_layers // 2]
-    start = 1
-    end = num_target_layers - 3
-    span = end - start
-    return [
-        round(start + (i * span) / (num_draft_layers - 1))
-        for i in range(num_draft_layers)
-    ]
-
-
 def extract_context_feature(
     hidden_states: list[torch.Tensor],
     layer_ids: list[int] | None,
@@ -557,11 +545,9 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         self.layers = nn.ModuleList(
             [Qwen3DFlashDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
-        self.target_layer_ids = _draft_value(
-            config,
-            "target_layer_ids",
-            build_target_layer_ids(config.num_target_layers, config.num_hidden_layers),
-        )
+        self.target_layer_ids = _draft_value(config, "target_layer_ids")
+        if self.target_layer_ids is None:
+            raise ValueError("Draft config must define dflash_config.target_layer_ids.")
         self.norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = Qwen3RotaryEmbedding(config)
         self.fc = nn.Linear(len(self.target_layer_ids) * config.hidden_size, config.hidden_size, bias=False)

--- a/dflash/model_mlx.py
+++ b/dflash/model_mlx.py
@@ -120,7 +120,6 @@ class DFlashConfig:
     max_position_embeddings: int
     block_size: int
     target_layer_ids: tuple[int, ...]
-    num_target_layers: int
     mask_token_id: int = 0
     rope_scaling: dict[str, Any] | None = None
     layer_types: tuple[str, ...] = field(default_factory=tuple)
@@ -453,7 +452,6 @@ def load_draft(draft_id: str) -> DFlashDraftModel:
         max_position_embeddings=cfg["max_position_embeddings"],
         block_size=int(dflash.get("block_size", cfg.get("block_size", 16))),
         target_layer_ids=tuple(dflash["target_layer_ids"]),
-        num_target_layers=cfg["num_target_layers"],
         mask_token_id=dflash["mask_token_id"],
         rope_scaling=rope,
         layer_types=layer_types,


### PR DESCRIPTION
Closes #156.

Makes `dflash_config.target_layer_ids` required instead of guessing it, and deletes `build_target_layer_ids`. Rebased onto 07ebd93. Full evidence in #156.

```python
self.target_layer_ids = _draft_value(config, "target_layer_ids")
if self.target_layer_ids is None:
    raise ValueError("Draft config must define dflash_config.target_layer_ids.")
```

Why:

- The guess never runs. All 20 checkpoints I could download set the key.
- If it did run it would usually be wrong. It passes the draft's layer count where the formula needs the number of target layers read, which matches only 6 of 20 checkpoints (18 of 20 with the right count). A wrong guess sets `fc`'s input width, so it surfaces as a weight shape mismatch rather than a missing config key.
- Because `dict.get` evaluates its default eagerly, the guess ran on every load, making the unread `num_target_layers` mandatory in every config. That's why the MLX `DFlashConfig` field goes too.

MLX already required the key with no fallback; torch now matches.

Verified by building the draft model from all 20 reachable configs, including both DFlash 2 ones, and checking `target_layer_ids`, `fc.in_features`, `block_size` and `mask_token_id` against each. All load, same as `main`. No released checkpoint changes behaviour.

