### PR TITLE
docs: add validated Jetson Thor DFlash2 serving setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,38 @@ dflash generate openai \
     "How many positive whole-number divisors does 196 have?"
 ```
 
+#### NVIDIA Jetson AGX Thor
+
+Server startup and generation with Qwen3.8-27B DFlash 2 were tested on a
+128 GB Jetson AGX Thor Developer Kit (`sm_110a`, Ubuntu 24.04, Linux aarch64)
+with vLLM commit `b389ac29465b33f9e9c534df221ea3c129e9793f`, NVIDIA PyTorch
+`2.13.0a0+9186a08b2c.nv26.07`, FlashInfer `0.6.17`, and CUDA 13.3-built
+kernels. The target used compressed-tensors NVFP4 weights and an FP8 E4M3 KV
+cache. The tested run used explicit V2 and FlashInfer architecture overrides:
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+export FLASHINFER_CUDA_ARCH_LIST=11.0a
+
+vllm serve /path/to/Qwen3.8-27B-NVFP4 \
+    --served-model-name Qwen/Qwen3.8-27B \
+    --max-model-len 262144 \
+    --kv-cache-dtype fp8 \
+    --gpu-memory-utilization 0.30 \
+    --kv-cache-memory-bytes 21474836480 \
+    --speculative-config \
+      '{"method":"dflash","model":"z-lab/Qwen3.8-27B-DFlash2","num_speculative_tokens":7}'
+```
+
+The explicit 20 GiB allocation makes vLLM skip automatic KV-cache memory
+sizing; model warmup and compilation still run. In the tested vLLM revision,
+`--gpu-memory-utilization 0.30` remained relevant to the startup free-memory
+check but did not size the KV cache. With the tested target, vLLM reported
+453,669 tokens of KV capacity (1.73 sequences at the 262,144-token limit).
+Capacity depends on the target architecture and KV-cache dtype, so verify the
+reported cache size and tune both memory values for the workloads sharing the
+device.
+
 ## 📊 Evaluation
 
 All benchmarks share the same datasets (gsm8k, math500, humaneval, mbpp, mt-bench), downloaded and cached by Hugging Face Datasets.


### PR DESCRIPTION
## Summary

- document a tested Qwen3.8-27B DFlash 2 configuration for the 128 GB Jetson AGX Thor Developer Kit
- pin the validated vLLM, NVIDIA PyTorch, FlashInfer, CUDA architecture, weight, and KV-cache formats
- show explicit KV allocation for a 262,144-token context limit
- clarify how `--kv-cache-memory-bytes` and `--gpu-memory-utilization` interact in the tested vLLM revision

## Validation

The upstream package workflow was reproduced locally on Python 3.12.13:

- built the sdist and wheel
- passed `twine check --strict`
- installed the generated wheel
- imported `dflash`
- smoke-tested `dflash`, `dflash generate`, and `dflash benchmark`

The documented configuration was also checked on a live 128 GB Jetson AGX Thor:

- vLLM V2 model runner active
- `DFlash2Qwen3ForCausalLM` draft model loaded
- text generation and health check successful
- FP8 E4M3 KV cache on `sm_110`
- `max_model_len=262144`
- 453,669 tokens of KV capacity, reported as 1.73 concurrent sequences at the 262,144-token limit

The 256K statement describes allocated KV capacity; it does not claim that a 256K-token prompt was executed.

## AI assistance disclosure

This documentation change was AI-assisted and has not yet received independent human code review. The commands, package checks, runtime configuration, and reported capacity were verified against the tested hardware and final diff.
