### PR TITLE
mlx: load Meta's Muse-Glimmer-30B-assistant DFlash head via a draft-adapter registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,12 @@ dflash generate transformers \
 
 ### MLX (Apple Silicon)
 
-The MLX backend supports DFlash 2 for Qwen3.8-27B, and DFlash for Qwen3,
-Qwen3.5, Qwen3.6, and Gemma 4. Qwen3.8 uses `reasoning_effort`: `low`, `medium`,
-or `xhigh` (default). For quantized targets or drafts, use `block_size <= 5`: MLX's current
+The MLX backend supports DFlash 2 for Qwen3.8-27B and Muse-Glimmer-30B, and DFlash
+for Qwen3, Qwen3.5, Qwen3.6, Gemma 4, and Muse-Glimmer-30B (Meta's
+[`Muse-Glimmer-30B-assistant`](https://huggingface.co/meta-models/Muse-Glimmer-30B-assistant)
+head loads as published). Qwen3.8 uses `reasoning_effort`: `low`, `medium`,
+or `xhigh` (default); Muse uses `reasoning_strength` as in the Transformers example.
+For quantized targets or drafts, use `block_size <= 5`: MLX's current
 quantized matmul kernel becomes less efficient at larger verify widths.
 The example below runs both the target and draft with 4-bit weights.
 
@@ -84,6 +87,21 @@ dflash generate mlx \
     --draft-bits 4 --block-size 5 --reasoning xhigh \
     "How many positive whole-number divisors does 196 have?"
 ```
+
+Muse-Glimmer-30B with Meta's DFlash head (or `--draft z-lab/Muse-Glimmer-30B-DFlash2`):
+
+```bash
+dflash generate mlx \
+    --model mlx-community/Muse-Glimmer-30B-4bit \
+    --draft meta-models/Muse-Glimmer-30B-assistant \
+    --draft-bits 4 --block-size 5 --reasoning low \
+    "How many positive whole-number divisors does 196 have?"
+```
+
+Measured on an M3 Ultra with the 4-bit target, greedy, 6 prompts x 256 tokens
+(`python -m dflash.bench_mlx`): no draft 40.7 tok/s; Meta head (4-bit) block 5 47.6 tok/s
+(1.17x, 2.9 accepted/step); DFlash 2 head (4-bit) block 5 50.8 tok/s (1.25x, 3.4 accepted/step).
+Block 16 is slower than no draft on this target (0.80x), consistent with the note above.
 
 ### OpenAI-compatible server
 

--- a/dflash/bench_mlx.py
+++ b/dflash/bench_mlx.py
@@ -1,0 +1,193 @@
+"""CLI benchmark for DFlash speculative decoding against plain mlx_lm generation."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import time
+from pathlib import Path
+
+import mlx.core as mx
+
+from .benchmark import apply_chat_template, load_mlx_models
+from .model_mlx import load as load_target
+from .model_mlx import make_sampler
+from .model_mlx import stream_generate as dflash_stream_generate
+
+DEFAULT_PROMPTS = Path(__file__).parent / "bench_prompts.json"
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark DFlash speculative decoding on MLX.")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--draft", help="Draft model id. Omit to run plain mlx_lm greedy/sampled generation.")
+    parser.add_argument("--draft-bits", type=int, choices=[4, 8])
+    parser.add_argument("--block-sizes", help="Comma-separated block sizes. Ignored without --draft.")
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--top-k", type=int, default=0)
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--prompts", help="JSON file with a list of chat prompt strings.")
+    parser.add_argument("--reasoning", help="Passed through to apply_chat_template.")
+    parser.add_argument("--out", required=True, help="JSONL output path.")
+    parser.add_argument(
+        "--baseline",
+        help="A prior baseline JSONL to check greedy token shas against, "
+        "for runs where this run has no draft-less rows of its own.",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_prompts(path: str | None) -> list[str]:
+    return json.loads(Path(path or DEFAULT_PROMPTS).read_text())
+
+
+def _sha256_tokens(tokens: list[int]) -> str:
+    return hashlib.sha256(json.dumps(tokens).encode()).hexdigest()
+
+
+def _load_baseline_shas(path: str | None) -> dict[int, str]:
+    if not path:
+        return {}
+    shas = {}
+    for line in Path(path).read_text().splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if row.get("draft") is None:
+            shas[row["prompt_index"]] = row["token_sha256"]
+    return shas
+
+
+def _run_baseline(model, tokenizer, prompt_text: str, args: argparse.Namespace) -> dict:
+    from mlx_lm import stream_generate as mlx_stream_generate
+
+    sampler = make_sampler(args.temperature, args.top_p, args.top_k)
+    tokens, text_parts, last = [], [], None
+    for r in mlx_stream_generate(model, tokenizer, prompt_text, max_tokens=args.max_tokens, sampler=sampler):
+        tokens.append(r.token)
+        text_parts.append(r.text)
+        last = r
+    return {
+        "prompt_tokens": last.prompt_tokens,
+        "gen_tokens": len(tokens),
+        "gen_tps": last.generation_tps,
+        "prompt_tps": last.prompt_tps,
+        "mean_accept": None,
+        "peak_gb": last.peak_memory,
+        "tokens": tokens,
+        "text": "".join(text_parts),
+    }
+
+
+def _run_draft(model, draft, tokenizer, prompt_text: str, block_size: int, args: argparse.Namespace) -> dict:
+    tokens, text_parts, accepted, last = [], [], [], None
+    for r in dflash_stream_generate(
+        model, draft, tokenizer, prompt_text,
+        block_size=block_size,
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+    ):
+        tokens.extend(r.tokens)
+        text_parts.append(r.text)
+        if r.accepted is not None:
+            accepted.append(r.accepted)
+        last = r
+    return {
+        "prompt_tokens": last.prompt_tokens,
+        "gen_tokens": len(tokens),
+        "gen_tps": last.generation_tps,
+        "prompt_tps": last.prompt_tps,
+        "mean_accept": statistics.mean(accepted) if accepted else None,
+        "peak_gb": last.peak_memory,
+        "tokens": tokens,
+        "text": "".join(text_parts),
+    }
+
+
+def _print_summary(rows: list[dict], baseline_shas: dict[int, str], temperature: float) -> None:
+    groups: dict[tuple, list[dict]] = {}
+    for row in rows:
+        groups.setdefault((row["draft"], row["block_size"]), []).append(row)
+
+    print(f"\n{'draft':<50} {'block':>6} {'mean_tps':>10} {'mean_accept':>12} {'greedy_match':>14}")
+    for (draft, block_size), group in sorted(groups.items(), key=lambda kv: (kv[0][0] or "", kv[0][1] or 0)):
+        mean_tps = statistics.mean(r["gen_tps"] for r in group)
+        accepts = [r["mean_accept"] for r in group if r["mean_accept"] is not None]
+        mean_accept = f"{statistics.mean(accepts):.2f}" if accepts else "n/a"
+        match = "n/a"
+        if temperature == 0 and baseline_shas:
+            mismatches = [
+                r["prompt_index"] for r in group
+                if r["prompt_index"] in baseline_shas and baseline_shas[r["prompt_index"]] != r["token_sha256"]
+            ]
+            match = "yes" if not mismatches else f"no {mismatches}"
+        print(f"{str(draft):<50} {str(block_size):>6} {mean_tps:>10.2f} {mean_accept:>12} {match:>14}")
+
+
+def main(argv=None) -> None:
+    args = _parse_args(argv)
+    mx.random.seed(0)
+    prompts = _load_prompts(args.prompts)
+
+    if args.draft:
+        model, draft, tokenizer = load_mlx_models(args.model, args.draft, args.draft_bits)
+        block_sizes = (
+            [int(x) for x in args.block_sizes.split(",")]
+            if args.block_sizes
+            else [int(draft.config.block_size)]
+        )
+    else:
+        model, tokenizer = load_target(args.model)
+        draft = None
+        block_sizes = [None]
+
+    known_shas = _load_baseline_shas(args.baseline)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    with out_path.open("w") as fh:
+        for prompt_index, prompt_str in enumerate(prompts):
+            messages = [{"role": "user", "content": prompt_str}]
+            prompt_text = apply_chat_template(tokenizer, messages, args.reasoning)
+            for block_size in block_sizes:
+                tic = time.perf_counter()
+                result = (
+                    _run_baseline(model, tokenizer, prompt_text, args)
+                    if draft is None
+                    else _run_draft(model, draft, tokenizer, prompt_text, block_size, args)
+                )
+                token_sha = _sha256_tokens(result["tokens"])
+                if draft is None:
+                    known_shas.setdefault(prompt_index, token_sha)
+                row = {
+                    "model": args.model,
+                    "draft": args.draft,
+                    "draft_bits": args.draft_bits,
+                    "block_size": block_size,
+                    "temperature": args.temperature,
+                    "prompt_index": prompt_index,
+                    "prompt_tokens": result["prompt_tokens"],
+                    "gen_tokens": result["gen_tokens"],
+                    "gen_tps": result["gen_tps"],
+                    "prompt_tps": result["prompt_tps"],
+                    "mean_accept": result["mean_accept"],
+                    "peak_gb": result["peak_gb"],
+                    "token_sha256": token_sha,
+                    "tokens": result["tokens"],
+                    "text_preview": result["text"][:120],
+                    "wall_s": time.perf_counter() - tic,
+                }
+                fh.write(json.dumps(row) + "\n")
+                fh.flush()
+                rows.append(row)
+
+    _print_summary(rows, known_shas, args.temperature)
+
+
+if __name__ == "__main__":
+    main()

--- a/dflash/bench_prompts.json
+++ b/dflash/bench_prompts.json
@@ -1,0 +1,8 @@
+[
+  "What year did the Berlin Wall fall?",
+  "Write a Python function that returns the k most frequent elements in a list, and explain its time complexity.",
+  "Write a 300-word essay on why tide pools are a good model system for studying climate change.",
+  "A train leaves Station A at 60 mph heading toward Station B, 210 miles away. A second train leaves Station B at the same time heading toward Station A at 90 mph. How long until they meet?",
+  "Extract the fields from this order into JSON with keys order_id, customer, items (list of {name, qty}), and total: \"Order #4471 for Priya Nair: 2x wireless mouse, 1x USB-C hub. Total $58.40.\"",
+  "请用中文解释什么是推理模型，并给出一个日常生活中的例子。"
+]

--- a/dflash/model_mlx.py
+++ b/dflash/model_mlx.py
@@ -3,7 +3,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import RLock
-from typing import Any
+from typing import Any, Callable
 
 import mlx.core as mx
 import mlx_lm.models.gated_delta as _gd_mod
@@ -120,7 +120,7 @@ class DFlashConfig:
     max_position_embeddings: int
     block_size: int
     target_layer_ids: tuple[int, ...]
-    num_target_layers: int
+    num_target_layers: int | None = None
     mask_token_id: int = 0
     rope_scaling: dict[str, Any] | None = None
     layer_types: tuple[str, ...] = field(default_factory=tuple)
@@ -366,6 +366,17 @@ class DFlashDraftModel(nn.Module):
         )
         lm = getattr(target_model, "language_model", target_model)
         self.lm_head = getattr(target_model, "lm_head", None) or getattr(lm, "lm_head", None) or self.embed_tokens.as_linear
+        # A draft config left at its structural defaults (multiplier 1.0, no softcap,
+        # as with Meta's v1 head) inherits the target's logit scale when the target
+        # has one (Glimmer does, Qwen targets don't) so draft probs land on the
+        # target's scale for rejection sampling. Greedy argmax is unaffected either way.
+        if self.config.output_multiplier == 1.0 and self.config.final_logit_softcapping is None:
+            target_args = getattr(target_model, "args", None)
+            if target_args is not None and hasattr(target_args, "output_multiplier"):
+                self.config.output_multiplier = target_args.output_multiplier
+                self.config.final_logit_softcapping = getattr(
+                    target_args, "final_logit_softcapping", None
+                )
         return self
 
     def make_cache(self):
@@ -427,37 +438,21 @@ def load(model_id: str):
     return mlx_lm_load(model_id)
 
 
-def load_draft(draft_id: str) -> DFlashDraftModel:
-    path = Path(snapshot_download(draft_id, allow_patterns=["*.safetensors", "*.json"]))
-    cfg = json.loads((path / "config.json").read_text())
+@dataclass
+class _DraftAdapter:
+    model_class: type
+    config_kwargs: Callable[[dict], dict]
+    remap_weights: Callable[[dict, dict], dict]
+
+
+def _dflash2_config_kwargs(cfg: dict) -> dict:
     dflash = cfg.get("dflash_config", {})
-    rope = cfg.get("rope_parameters") or cfg.get("rope_scaling")
-    layer_types = tuple(cfg.get("layer_types") or ["full_attention"] * cfg["num_hidden_layers"])
-    if len(layer_types) != cfg["num_hidden_layers"]:
-        raise ValueError("Draft config layer_types length must match num_hidden_layers.")
-    unknown_layer_types = set(layer_types) - {"full_attention", "sliding_attention"}
-    if unknown_layer_types:
-        raise ValueError(f"Unsupported draft layer_types: {sorted(unknown_layer_types)}.")
-    if "sliding_attention" in layer_types and cfg.get("sliding_window") is None:
-        raise ValueError("Draft config must define sliding_window for sliding_attention layers.")
-    config = DFlashConfig(
-        hidden_size=cfg["hidden_size"],
-        num_hidden_layers=cfg["num_hidden_layers"],
-        num_attention_heads=cfg["num_attention_heads"],
-        num_key_value_heads=cfg["num_key_value_heads"],
-        head_dim=cfg["head_dim"],
-        intermediate_size=cfg["intermediate_size"],
+    return dict(
         vocab_size=cfg["vocab_size"],
-        rms_norm_eps=cfg["rms_norm_eps"],
-        rope_theta=cfg.get("rope_theta", (rope or {}).get("rope_theta", 10000.0)),
-        max_position_embeddings=cfg["max_position_embeddings"],
         block_size=int(dflash.get("block_size", cfg.get("block_size", 16))),
         target_layer_ids=tuple(dflash["target_layer_ids"]),
-        num_target_layers=cfg["num_target_layers"],
+        num_target_layers=cfg.get("num_target_layers"),
         mask_token_id=dflash["mask_token_id"],
-        rope_scaling=rope,
-        layer_types=layer_types,
-        sliding_window=cfg.get("sliding_window"),
         final_logit_softcapping=dflash.get(
             "final_logit_softcapping", cfg.get("final_logit_softcapping")
         ),
@@ -469,17 +464,105 @@ def load_draft(draft_id: str) -> DFlashDraftModel:
         selector_top_k=int(dflash.get("selector_top_k", 0)),
         is_causal=cfg.get("is_causal"),
     )
-    weights = {k: v for f in path.glob("*.safetensors") for k, v in mx.load(str(f)).items()}
-    model_class = (
-        DFlash2DraftModel
-        if "DFlash2DraftModel" in (cfg.get("architectures") or [])
-        else DFlashDraftModel
+
+
+def _meta_v1_config_kwargs(cfg: dict) -> dict:
+    return dict(
+        vocab_size=cfg.get("vocab_size", 202048),
+        block_size=int(cfg.get("block_size", 16)),
+        target_layer_ids=tuple(cfg["target_layer_ids"]),
+        num_target_layers=None,
+        mask_token_id=cfg["mask_token_id"],
+        final_logit_softcapping=cfg.get("final_logit_softcapping"),
+        input_embedding_scale=float(cfg.get("input_embedding_scale", 1.0)),
+        output_multiplier=float(cfg.get("output_multiplier", 1.0)),
+        # vLLM's dflash_config sets causal=False for this head: in-block attention
+        # is bidirectional, unlike the sliding-causal default the layer_types imply.
+        is_causal=False,
     )
-    if model_class is DFlash2DraftModel:
-        for name in ("predecessor_codebook", "successor_codebook"):
-            key = f"candidate_selector.{name}"
-            weights[f"{key}.weight"] = weights.pop(key)
-    model = model_class(config)
+
+
+def _remap_dflash2_weights(cfg: dict, weights: dict) -> dict:
+    weights = dict(weights)
+    for name in ("predecessor_codebook", "successor_codebook"):
+        key = f"candidate_selector.{name}"
+        weights[f"{key}.weight"] = weights.pop(key)
+    return weights
+
+
+def _remap_meta_v1_weights(cfg: dict, weights: dict) -> dict:
+    prefixes = {"encoder.fc.": "fc.", "encoder.output_norm_enc.": "hidden_norm."}
+    out = {}
+    for k, v in weights.items():
+        for old, new in prefixes.items():
+            if k.startswith(old):
+                k = new + k[len(old):]
+                break
+        out[k] = v
+    return out
+
+
+_DRAFT_ADAPTERS: dict[str, _DraftAdapter] = {
+    "DFlash2DraftModel": _DraftAdapter(
+        DFlash2DraftModel, _dflash2_config_kwargs, _remap_dflash2_weights
+    ),
+    "MuseGlimmerAssistantModel": _DraftAdapter(
+        DFlashDraftModel, _meta_v1_config_kwargs, _remap_meta_v1_weights
+    ),
+}
+
+
+def _draft_adapter(cfg: dict) -> _DraftAdapter:
+    architecture = (cfg.get("architectures") or [None])[0]
+    adapter = _DRAFT_ADAPTERS.get(architecture)
+    if adapter is None:
+        raise ValueError(f"Unsupported draft architecture: {architecture!r}")
+    return adapter
+
+
+def _draft_model_class(cfg: dict) -> type:
+    return _draft_adapter(cfg).model_class
+
+
+def _draft_config(cfg: dict) -> DFlashConfig:
+    layer_types = tuple(cfg.get("layer_types") or ["full_attention"] * cfg["num_hidden_layers"])
+    if len(layer_types) != cfg["num_hidden_layers"]:
+        raise ValueError("Draft config layer_types length must match num_hidden_layers.")
+    unknown_layer_types = set(layer_types) - {"full_attention", "sliding_attention"}
+    if unknown_layer_types:
+        raise ValueError(f"Unsupported draft layer_types: {sorted(unknown_layer_types)}.")
+    if "sliding_attention" in layer_types and cfg.get("sliding_window") is None:
+        raise ValueError("Draft config must define sliding_window for sliding_attention layers.")
+
+    rope = cfg.get("rope_parameters") or cfg.get("rope_scaling")
+    return DFlashConfig(
+        hidden_size=cfg["hidden_size"],
+        num_hidden_layers=cfg["num_hidden_layers"],
+        num_attention_heads=cfg["num_attention_heads"],
+        num_key_value_heads=cfg["num_key_value_heads"],
+        head_dim=cfg["head_dim"],
+        intermediate_size=cfg["intermediate_size"],
+        rms_norm_eps=cfg["rms_norm_eps"],
+        rope_theta=cfg.get("rope_theta", (rope or {}).get("rope_theta", 10000.0)),
+        max_position_embeddings=cfg["max_position_embeddings"],
+        rope_scaling=rope,
+        layer_types=layer_types,
+        sliding_window=cfg.get("sliding_window"),
+        **_draft_adapter(cfg).config_kwargs(cfg),
+    )
+
+
+def _remap_draft_weights(cfg: dict, weights: dict) -> dict:
+    return _draft_adapter(cfg).remap_weights(cfg, weights)
+
+
+def load_draft(draft_id: str) -> DFlashDraftModel:
+    path = Path(snapshot_download(draft_id, allow_patterns=["*.safetensors", "*.json"]))
+    cfg = json.loads((path / "config.json").read_text())
+    config = _draft_config(cfg)
+    weights = {k: v for f in path.glob("*.safetensors") for k, v in mx.load(str(f)).items()}
+    weights = _remap_draft_weights(cfg, weights)
+    model = _draft_model_class(cfg)(config)
     model.eval()
     model.load_weights(list(weights.items()))
     mx.eval(model.parameters())

--- a/tests/fixtures/assistant-config.json
+++ b/tests/fixtures/assistant-config.json
@@ -1,0 +1,42 @@
+{
+  "architectures": [
+    "MuseGlimmerAssistantModel"
+  ],
+  "attention_dropout": 0,
+  "block_size": 16,
+  "bos_token_id": 200000,
+  "dtype": "bfloat16",
+  "eos_token_id": 200001,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 6656,
+  "intermediate_size": 19968,
+  "layer_types": [
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention"
+  ],
+  "mask_token_id": 201818,
+  "max_position_embeddings": 131072,
+  "model_type": "muse_glimmer_assistant",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 5,
+  "num_key_value_heads": 8,
+  "pad_token_id": 200018,
+  "rms_norm_eps": 1e-05,
+  "rope_parameters": {
+    "rope_theta": 500000.0,
+    "rope_type": "default"
+  },
+  "sliding_window": 2048,
+  "target_layer_ids": [
+    1,
+    13,
+    25,
+    37,
+    49
+  ],
+  "transformers_version": "5.15.0.dev0"
+}

--- a/tests/fixtures/assistant-safetensors-header.json
+++ b/tests/fixtures/assistant-safetensors-header.json
@@ -1,0 +1,621 @@
+{
+  "__metadata__": {
+    "format": "pt"
+  },
+  "encoder.fc.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      33280
+    ],
+    "data_offsets": [
+      0,
+      443023360
+    ]
+  },
+  "encoder.output_norm_enc.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      443023360,
+      443036672
+    ]
+  },
+  "layers.0.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      443036672,
+      443049984
+    ]
+  },
+  "layers.0.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      443049984,
+      708864000
+    ]
+  },
+  "layers.0.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      708864000,
+      974678016
+    ]
+  },
+  "layers.0.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      974678016,
+      1240492032
+    ]
+  },
+  "layers.0.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      1240492032,
+      1240505344
+    ]
+  },
+  "layers.0.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      1240505344,
+      1240505600
+    ]
+  },
+  "layers.0.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      1240505600,
+      1254137088
+    ]
+  },
+  "layers.0.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      1254137088,
+      1308663040
+    ]
+  },
+  "layers.0.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      1308663040,
+      1308663296
+    ]
+  },
+  "layers.0.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      1308663296,
+      1363189248
+    ]
+  },
+  "layers.0.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      1363189248,
+      1376820736
+    ]
+  },
+  "layers.1.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      1376820736,
+      1376834048
+    ]
+  },
+  "layers.1.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      1376834048,
+      1642648064
+    ]
+  },
+  "layers.1.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      1642648064,
+      1908462080
+    ]
+  },
+  "layers.1.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      1908462080,
+      2174276096
+    ]
+  },
+  "layers.1.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      2174276096,
+      2174289408
+    ]
+  },
+  "layers.1.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      2174289408,
+      2174289664
+    ]
+  },
+  "layers.1.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      2174289664,
+      2187921152
+    ]
+  },
+  "layers.1.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      2187921152,
+      2242447104
+    ]
+  },
+  "layers.1.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      2242447104,
+      2242447360
+    ]
+  },
+  "layers.1.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      2242447360,
+      2296973312
+    ]
+  },
+  "layers.1.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      2296973312,
+      2310604800
+    ]
+  },
+  "layers.2.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      2310604800,
+      2310618112
+    ]
+  },
+  "layers.2.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      2310618112,
+      2576432128
+    ]
+  },
+  "layers.2.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      2576432128,
+      2842246144
+    ]
+  },
+  "layers.2.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      2842246144,
+      3108060160
+    ]
+  },
+  "layers.2.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      3108060160,
+      3108073472
+    ]
+  },
+  "layers.2.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      3108073472,
+      3108073728
+    ]
+  },
+  "layers.2.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      3108073728,
+      3121705216
+    ]
+  },
+  "layers.2.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      3121705216,
+      3176231168
+    ]
+  },
+  "layers.2.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      3176231168,
+      3176231424
+    ]
+  },
+  "layers.2.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      3176231424,
+      3230757376
+    ]
+  },
+  "layers.2.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      3230757376,
+      3244388864
+    ]
+  },
+  "layers.3.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      3244388864,
+      3244402176
+    ]
+  },
+  "layers.3.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      3244402176,
+      3510216192
+    ]
+  },
+  "layers.3.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      3510216192,
+      3776030208
+    ]
+  },
+  "layers.3.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      3776030208,
+      4041844224
+    ]
+  },
+  "layers.3.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      4041844224,
+      4041857536
+    ]
+  },
+  "layers.3.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      4041857536,
+      4041857792
+    ]
+  },
+  "layers.3.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      4041857792,
+      4055489280
+    ]
+  },
+  "layers.3.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      4055489280,
+      4110015232
+    ]
+  },
+  "layers.3.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      4110015232,
+      4110015488
+    ]
+  },
+  "layers.3.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      4110015488,
+      4164541440
+    ]
+  },
+  "layers.3.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      4164541440,
+      4178172928
+    ]
+  },
+  "layers.4.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      4178172928,
+      4178186240
+    ]
+  },
+  "layers.4.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      4178186240,
+      4444000256
+    ]
+  },
+  "layers.4.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      4444000256,
+      4709814272
+    ]
+  },
+  "layers.4.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      4709814272,
+      4975628288
+    ]
+  },
+  "layers.4.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      4975628288,
+      4975641600
+    ]
+  },
+  "layers.4.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      4975641600,
+      4975641856
+    ]
+  },
+  "layers.4.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      4975641856,
+      4989273344
+    ]
+  },
+  "layers.4.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      4989273344,
+      5043799296
+    ]
+  },
+  "layers.4.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      5043799296,
+      5043799552
+    ]
+  },
+  "layers.4.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      5043799552,
+      5098325504
+    ]
+  },
+  "layers.4.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      5098325504,
+      5111956992
+    ]
+  },
+  "norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      5111956992,
+      5111970304
+    ]
+  }
+}

--- a/tests/fixtures/dflash2-config.json
+++ b/tests/fixtures/dflash2-config.json
@@ -1,0 +1,59 @@
+{
+  "architectures": [
+    "DFlash2DraftModel"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 200000,
+  "is_causal": false,
+  "dflash_config": {
+    "block_size": 16,
+    "conv_group_size": 16,
+    "conv_kernel_size": 2,
+    "final_logit_softcapping": 20.0,
+    "mask_token_id": 201818,
+    "output_multiplier": 0.19611613513818404,
+    "selector_rank": 256,
+    "selector_top_k": 16,
+    "target_layer_ids": [
+      1,
+      13,
+      25,
+      37,
+      49
+    ]
+  },
+  "dtype": "bfloat16",
+  "eos_token_id": 200001,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 6656,
+  "initializer_range": 0.02,
+  "intermediate_size": 19968,
+  "layer_types": [
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention"
+  ],
+  "max_position_embeddings": 131072,
+  "max_window_layers": 5,
+  "model_type": "qwen3",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 5,
+  "num_key_value_heads": 8,
+  "num_target_layers": 52,
+  "pad_token_id": 200018,
+  "rms_norm_eps": 1e-05,
+  "rope_parameters": {
+    "rope_theta": 500000.0,
+    "rope_type": "default"
+  },
+  "sliding_window": 2048,
+  "tie_word_embeddings": false,
+  "transformers_version": "5.15.0",
+  "use_cache": false,
+  "use_sliding_window": true,
+  "vocab_size": 202048
+}

--- a/tests/fixtures/dflash2-safetensors-header.json
+++ b/tests/fixtures/dflash2-safetensors-header.json
@@ -1,0 +1,881 @@
+{
+  "candidate_selector.hidden_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      256,
+      6656
+    ],
+    "data_offsets": [
+      0,
+      3407872
+    ]
+  },
+  "candidate_selector.predecessor_codebook": {
+    "dtype": "BF16",
+    "shape": [
+      202048,
+      256
+    ],
+    "data_offsets": [
+      3407872,
+      106856448
+    ]
+  },
+  "candidate_selector.successor_codebook": {
+    "dtype": "BF16",
+    "shape": [
+      202048,
+      256
+    ],
+    "data_offsets": [
+      106856448,
+      210305024
+    ]
+  },
+  "fc.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      33280
+    ],
+    "data_offsets": [
+      210305024,
+      653328384
+    ]
+  },
+  "hidden_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      653328384,
+      653341696
+    ]
+  },
+  "layers.0.attention_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      653341696,
+      653394944
+    ]
+  },
+  "layers.0.attention_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      653394944,
+      675546112
+    ]
+  },
+  "layers.0.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      675546112,
+      675559424
+    ]
+  },
+  "layers.0.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      675559424,
+      941373440
+    ]
+  },
+  "layers.0.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      941373440,
+      1207187456
+    ]
+  },
+  "layers.0.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      1207187456,
+      1473001472
+    ]
+  },
+  "layers.0.mlp_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      1473001472,
+      1473054720
+    ]
+  },
+  "layers.0.mlp_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      1473054720,
+      1495205888
+    ]
+  },
+  "layers.0.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      1495205888,
+      1495219200
+    ]
+  },
+  "layers.0.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      1495219200,
+      1495219456
+    ]
+  },
+  "layers.0.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      1495219456,
+      1508850944
+    ]
+  },
+  "layers.0.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      1508850944,
+      1563376896
+    ]
+  },
+  "layers.0.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      1563376896,
+      1563377152
+    ]
+  },
+  "layers.0.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      1563377152,
+      1617903104
+    ]
+  },
+  "layers.0.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      1617903104,
+      1631534592
+    ]
+  },
+  "layers.1.attention_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      1631534592,
+      1631587840
+    ]
+  },
+  "layers.1.attention_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      1631587840,
+      1653739008
+    ]
+  },
+  "layers.1.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      1653739008,
+      1653752320
+    ]
+  },
+  "layers.1.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      1653752320,
+      1919566336
+    ]
+  },
+  "layers.1.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      1919566336,
+      2185380352
+    ]
+  },
+  "layers.1.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      2185380352,
+      2451194368
+    ]
+  },
+  "layers.1.mlp_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      2451194368,
+      2451247616
+    ]
+  },
+  "layers.1.mlp_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      2451247616,
+      2473398784
+    ]
+  },
+  "layers.1.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      2473398784,
+      2473412096
+    ]
+  },
+  "layers.1.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      2473412096,
+      2473412352
+    ]
+  },
+  "layers.1.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      2473412352,
+      2487043840
+    ]
+  },
+  "layers.1.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      2487043840,
+      2541569792
+    ]
+  },
+  "layers.1.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      2541569792,
+      2541570048
+    ]
+  },
+  "layers.1.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      2541570048,
+      2596096000
+    ]
+  },
+  "layers.1.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      2596096000,
+      2609727488
+    ]
+  },
+  "layers.2.attention_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      2609727488,
+      2609780736
+    ]
+  },
+  "layers.2.attention_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      2609780736,
+      2631931904
+    ]
+  },
+  "layers.2.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      2631931904,
+      2631945216
+    ]
+  },
+  "layers.2.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      2631945216,
+      2897759232
+    ]
+  },
+  "layers.2.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      2897759232,
+      3163573248
+    ]
+  },
+  "layers.2.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      3163573248,
+      3429387264
+    ]
+  },
+  "layers.2.mlp_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      3429387264,
+      3429440512
+    ]
+  },
+  "layers.2.mlp_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      3429440512,
+      3451591680
+    ]
+  },
+  "layers.2.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      3451591680,
+      3451604992
+    ]
+  },
+  "layers.2.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      3451604992,
+      3451605248
+    ]
+  },
+  "layers.2.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      3451605248,
+      3465236736
+    ]
+  },
+  "layers.2.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      3465236736,
+      3519762688
+    ]
+  },
+  "layers.2.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      3519762688,
+      3519762944
+    ]
+  },
+  "layers.2.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      3519762944,
+      3574288896
+    ]
+  },
+  "layers.2.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      3574288896,
+      3587920384
+    ]
+  },
+  "layers.3.attention_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      3587920384,
+      3587973632
+    ]
+  },
+  "layers.3.attention_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      3587973632,
+      3610124800
+    ]
+  },
+  "layers.3.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      3610124800,
+      3610138112
+    ]
+  },
+  "layers.3.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      3610138112,
+      3875952128
+    ]
+  },
+  "layers.3.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      3875952128,
+      4141766144
+    ]
+  },
+  "layers.3.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      4141766144,
+      4407580160
+    ]
+  },
+  "layers.3.mlp_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      4407580160,
+      4407633408
+    ]
+  },
+  "layers.3.mlp_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      4407633408,
+      4429784576
+    ]
+  },
+  "layers.3.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      4429784576,
+      4429797888
+    ]
+  },
+  "layers.3.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      4429797888,
+      4429798144
+    ]
+  },
+  "layers.3.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      4429798144,
+      4443429632
+    ]
+  },
+  "layers.3.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      4443429632,
+      4497955584
+    ]
+  },
+  "layers.3.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      4497955584,
+      4497955840
+    ]
+  },
+  "layers.3.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      4497955840,
+      4552481792
+    ]
+  },
+  "layers.3.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      4552481792,
+      4566113280
+    ]
+  },
+  "layers.4.attention_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      4566113280,
+      4566166528
+    ]
+  },
+  "layers.4.attention_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      4566166528,
+      4588317696
+    ]
+  },
+  "layers.4.input_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      4588317696,
+      4588331008
+    ]
+  },
+  "layers.4.mlp.down_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      19968
+    ],
+    "data_offsets": [
+      4588331008,
+      4854145024
+    ]
+  },
+  "layers.4.mlp.gate_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      4854145024,
+      5119959040
+    ]
+  },
+  "layers.4.mlp.up_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      19968,
+      6656
+    ],
+    "data_offsets": [
+      5119959040,
+      5385773056
+    ]
+  },
+  "layers.4.mlp_conv.base_kernel": {
+    "dtype": "BF16",
+    "shape": [
+      2,
+      2,
+      6656
+    ],
+    "data_offsets": [
+      5385773056,
+      5385826304
+    ]
+  },
+  "layers.4.mlp_conv.kernel_projection.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1664,
+      6656
+    ],
+    "data_offsets": [
+      5385826304,
+      5407977472
+    ]
+  },
+  "layers.4.post_attention_layernorm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      5407977472,
+      5407990784
+    ]
+  },
+  "layers.4.self_attn.k_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      5407990784,
+      5407991040
+    ]
+  },
+  "layers.4.self_attn.k_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      5407991040,
+      5421622528
+    ]
+  },
+  "layers.4.self_attn.o_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656,
+      4096
+    ],
+    "data_offsets": [
+      5421622528,
+      5476148480
+    ]
+  },
+  "layers.4.self_attn.q_norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      128
+    ],
+    "data_offsets": [
+      5476148480,
+      5476148736
+    ]
+  },
+  "layers.4.self_attn.q_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      4096,
+      6656
+    ],
+    "data_offsets": [
+      5476148736,
+      5530674688
+    ]
+  },
+  "layers.4.self_attn.v_proj.weight": {
+    "dtype": "BF16",
+    "shape": [
+      1024,
+      6656
+    ],
+    "data_offsets": [
+      5530674688,
+      5544306176
+    ]
+  },
+  "norm.weight": {
+    "dtype": "BF16",
+    "shape": [
+      6656
+    ],
+    "data_offsets": [
+      5544306176,
+      5544319488
+    ]
+  }
+}

--- a/tests/test_muse_glimmer_adapter.py
+++ b/tests/test_muse_glimmer_adapter.py
@@ -1,0 +1,106 @@
+"""Draft-adapter unit tests. No weights, no network: config/remap logic only.
+
+Fixtures under tests/fixtures/ are verbatim copies of the real checkpoints'
+config.json and safetensors headers (see reference/README.md in the port
+workspace for provenance).
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+from mlx.utils import tree_flatten
+
+from dflash.model_mlx import (
+    DFlash2DraftModel,
+    DFlashDraftModel,
+    _draft_config,
+    _draft_model_class,
+    _remap_draft_weights,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _tensor_names(header: dict) -> list[str]:
+    return [k for k in header if k != "__metadata__"]
+
+
+def _param_keys(model) -> set[str]:
+    return {k for k, _ in tree_flatten(model.parameters())}
+
+
+def test_meta_v1_config():
+    cfg = _load("assistant-config.json")
+    config = _draft_config(cfg)
+
+    assert config.block_size == 16
+    assert config.mask_token_id == 201818
+    assert config.target_layer_ids == (1, 13, 25, 37, 49)
+    assert config.vocab_size == 202048
+    assert config.is_causal is False
+    assert config.sliding_window == 2048
+    assert config.layer_types == ("sliding_attention",) * 5
+    assert config.num_hidden_layers == 5
+    assert config.hidden_size == 6656
+    assert config.rope_theta == 500000.0
+
+
+def test_meta_v1_architecture_selects_dflash_draft_model():
+    cfg = _load("assistant-config.json")
+    assert _draft_model_class(cfg) is DFlashDraftModel
+
+
+def test_meta_v1_weight_remap_covers_every_model_parameter():
+    cfg = _load("assistant-config.json")
+    header = _load("assistant-safetensors-header.json")
+    synthetic = {name: mx.zeros((1,)) for name in _tensor_names(header)}
+
+    remapped = _remap_draft_weights(cfg, synthetic)
+    model = DFlashDraftModel(_draft_config(cfg))
+
+    # embed_tokens/lm_head are bound from the target later and hold no
+    # parameters of their own until then, so they never appear here.
+    assert set(remapped.keys()) == _param_keys(model)
+
+
+def test_dflash2_config():
+    cfg = _load("dflash2-config.json")
+    config = _draft_config(cfg)
+
+    assert config.block_size == 16
+    assert config.mask_token_id == 201818
+    assert config.target_layer_ids == (1, 13, 25, 37, 49)
+    assert config.vocab_size == 202048
+    assert config.is_causal is False
+    assert config.selector_rank == 256
+    assert config.selector_top_k == 16
+    assert config.conv_kernel_size == 2
+    assert config.conv_group_size == 16
+    assert config.num_target_layers == 52
+
+
+def test_dflash2_architecture_selects_dflash2_draft_model():
+    cfg = _load("dflash2-config.json")
+    assert _draft_model_class(cfg) is DFlash2DraftModel
+
+
+def test_dflash2_weight_remap_covers_every_model_parameter():
+    cfg = _load("dflash2-config.json")
+    header = _load("dflash2-safetensors-header.json")
+    synthetic = {name: mx.zeros((1,)) for name in _tensor_names(header)}
+
+    remapped = _remap_draft_weights(cfg, synthetic)
+    model = DFlash2DraftModel(_draft_config(cfg))
+
+    assert set(remapped.keys()) == _param_keys(model)
+
+
+def test_unknown_architecture_raises():
+    with pytest.raises(ValueError, match="SomeOtherModel"):
+        _draft_model_class({"architectures": ["SomeOtherModel"]})


### PR DESCRIPTION
## What

Adds Muse-Glimmer-30B to the MLX backend. Meta's `meta-models/Muse-Glimmer-30B-assistant` (DFlash v1) loads as published, no weight conversion, alongside `z-lab/Muse-Glimmer-30B-DFlash2`, against mlx-lm's `muse_glimmer` target (mlx-lm git main; the PyPI release predates Glimmer).

## Why

The README lists Muse-Glimmer-30B for Transformers only. On Apple Silicon there was no way to run either head. Meta's checkpoint is Qwen3-shaped (same layout `DFlashDraftModel` already implements; vLLM's `MuseGlimmerAssistantConfig` subclasses `Qwen3Config` for the same reason), so it only needs what vLLM also patches in:

| | value |
|---|---|
| weight remap | `encoder.fc.` -> `fc.`, `encoder.output_norm_enc.` -> `hidden_norm.` |
| `vocab_size` | 202048 (absent from the checkpoint; Qwen3's default would misindex the mask token) |
| `is_causal` | `False` (bidirectional in-block attention; the loader would otherwise default the sliding layers to causal) |

## How

- `load_draft` now dispatches through `_DRAFT_ADAPTERS`, a dict keyed on `config.architectures[0]` mapping to (model class, config normalizer, weight remap). The existing `DFlash2DraftModel` handling moves into its entry unchanged; `MuseGlimmerAssistantModel` is the new entry. Unknown architectures raise with the name. `DFlashConfig.num_target_layers` becomes optional (only used when `target_layer_ids` is absent).
- `bind()` inherits the target's `output_multiplier` / `final_logit_softcapping` when the draft config leaves them at defaults, so v1 draft probs sit on the target's scale for rejection sampling. Qwen targets have neither attribute and are unaffected.
- `dflash/bench_mlx.py`: with/without-draft benchmark writing one JSONL row per prompt and block size (tok/s, accepted tokens per step, peak memory, full token list and its SHA-256), with a `--baseline` option.
- `tests/test_muse_glimmer_adapter.py`: weight-free. Fixtures are the real `config.json` and safetensors headers of both heads; asserts the remapped key set equals `DFlashDraftModel` / `DFlash2DraftModel` parameter keys, plus config fields and the unknown-architecture error. 7 tests, ~1 s.
- README: Muse-Glimmer-30B added to the MLX section with an example and the numbers below.

Generate loop, attention, rejection sampler and cache trimming are untouched.

## Measured

M3 Ultra (103 GB), mlx 0.32.2, mlx-lm 0.32.0 (git main), `mlx-community/Muse-Glimmer-30B-4bit`, greedy, `Reasoning strength: low`, 6 prompts x 256 new tokens, one request at a time.

| draft | block | tok/s | speedup | accepted / step |
|---|---:|---:|---:|---:|
| none (plain `mlx_lm.stream_generate`) | - | 40.7 | 1.00x | - |
| Meta assistant, bf16 | 5 | 45.8 | 1.12x | 2.99 |
| Meta assistant, 4-bit | 5 | 47.6 | 1.17x | 2.93 |
| Meta assistant, 4-bit | 8 | 40.8 | 1.00x | 3.63 |
| Meta assistant, 4-bit | 16 | 32.6 | 0.80x | 4.68 |
| DFlash 2, 4-bit | 5 | 50.8 | 1.25x | 3.36 |
| DFlash 2, 4-bit | 8 | 45.8 | 1.13x | 4.19 |
| DFlash 2, 4-bit | 16 | 37.0 | 0.91x | 5.47 |

Block 5 is the crossover on a quantized target, matching the README's existing `block_size <= 5` note. On an abliterated 4-bit Glimmer, acceptance for both heads is within 0.1 of the stock model.

One note for reviewers: greedy token equality with plain decoding does not hold on this target in bf16. Replaying the baseline's own tokens through the target alone, single-step vs one batched pass, flips the argmax at near-tie positions (top-2 margin 0.0 to 0.4 under the tanh cap of 20). So the bench reports SHAs but the correctness evidence is by-construction verification plus healthy acceptance, not a token-exact match.

Under sampling (T=1, top-p 0.95, top-k 64) the v1 head accepts only 1.16 tokens/step with the current independent per-position proposal; that is a separate, behavior-changing fix, in #169.