### PR TITLE
mlx: propose argmax tokens for v1 drafts under sampling

### DIFF
--- a/dflash/model_mlx.py
+++ b/dflash/model_mlx.py
@@ -806,10 +806,17 @@ def _stream_generate(
                 else:
                     draft_logits = draft(block, hidden, draft_cache, logits_start=1)
                     if temperature > 0:
-                        draft_probs = _sampling_probs(
-                            draft_logits, temperature, top_p, top_k
+                        # v1 block positions are independent marginals, so sampling
+                        # each one separately yields an incoherent sequence the
+                        # target rejects almost everything; propose argmax instead
+                        # and rejection-sample against a one-hot proposal.
+                        draft_tokens = mx.argmax(draft_logits, axis=-1)
+                        draft_probs = mx.put_along_axis(
+                            mx.zeros(draft_logits.shape, dtype=mx.float32),
+                            draft_tokens[..., None],
+                            mx.ones(draft_tokens[..., None].shape, dtype=mx.float32),
+                            axis=-1,
                         )
-                        draft_tokens = _sample_probs(draft_probs)
                         draft_indices = None
                     else:
                         draft_tokens = mx.argmax(draft_logits, axis=-1)


### PR DESCRIPTION
## Problem

In `_stream_generate`, a v1 draft at `temperature > 0` samples every block position independently from its own distribution (`_sampling_probs` then `_sample_probs`). A v1 head's positions are marginals, not a joint sequence distribution, so the sampled block is incoherent and the target rejects nearly all of it.

Measured with `meta-models/Muse-Glimmer-30B-assistant` (4-bit) on `mlx-community/Muse-Glimmer-30B-4bit`, M3 Ultra, T=1 / top-p 0.95 / top-k 64, 6 prompts x 256 tokens:

| proposal policy | block | tok/s | vs no draft | accepted / step |
|---|---:|---:|---:|---:|
| none | - | 40.1 | 1.00x | - |
| independent per-position sampling (current) | 5 | 18.2 | 0.45x | 1.16 |
| independent per-position sampling (current) | 8 | 12.8 | 0.32x | 1.16 |
| argmax proposal (this PR) | 5 | 47.2 | 1.18x | 2.96 |
| argmax proposal (this PR) | 8 | 38.6 | 0.96x | 3.49 |

Greedy acceptance for the same head is 2.93 at block 5, so the fix restores the head's full acceptance. `DFlash2DraftModel` is unaffected either way (its candidate selector already proposes a coherent block; 3.35 accepted/step at the same settings).

## Fix

For non-DFlash2 drafts at `temperature > 0`, propose `argmax(draft_logits)` per position and pass a one-hot `draft_probs` into the existing `_rejection_sample` (`draft_indices=None`). With `q` one-hot the accept test `u * q < p` reduces to `u < p(token)` and the residual `max(p - q, 0)` renormalized is the target distribution with the rejected token removed, i.e. the standard greedy-draft rejection scheme. The output distribution is exactly the target's; only the proposal changed. This is also what vLLM's DFlash proposer does.

`temperature == 0` path and the DFlash 2 path are untouched. 10 insertions, 3 deletions.

## Note

This changes sampled-mode behavior for every v1 head on the MLX backend (Qwen3 / Qwen3.5 / Qwen3.6 / Gemma 4 drafts), not just Muse. I only measured Muse; if you have a Qwen3 v1 head bench handy it is worth a look, but the argument above is not model-specific.

Independent of the Muse-Glimmer adapter PR (#168); either can land first.